### PR TITLE
Fix missing validation handling

### DIFF
--- a/src/middleware/validate.js
+++ b/src/middleware/validate.js
@@ -1,0 +1,11 @@
+const { validationResult } = require('express-validator');
+
+function validate(req, res, next) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+}
+
+module.exports = validate;

--- a/src/routes/pokemon.js
+++ b/src/routes/pokemon.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const { authenticateToken, authorizeRole } = require("../middleware/auth");
 const pokemonController = require("../controllers/pokemon");
 const { pokemonValidationRules } = require("../validators/pokemon");
+const validate = require("../middleware/validate");
 
 // ✅ Toutes les routes nécessitent une connexion (admin ou user)
 router.get("/", authenticateToken, pokemonController.getAllPokemons);
@@ -13,12 +14,14 @@ router.post(
   "/",
   authenticateToken,
   pokemonValidationRules.create,
+  validate,
   pokemonController.createPokemon
 );
 router.put(
   "/:id",
   authenticateToken,
   pokemonValidationRules.update,
+  validate,
   pokemonController.updatePokemon
 );
 


### PR DESCRIPTION
## Summary
- add middleware to send validation errors back to clients
- use new validation middleware on Pokémon routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687bb5914f488333b33d3ab5d37f7edc